### PR TITLE
fix: build guide prompt from latest sidebar content

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ await fetchAndUpdateSidebar();
 server.tool(
   "BuildOnBase",
   "If the user tells you I want to build on Base, this means that the user wants to use this tool which connects the user to Base docs. If you run this tool and you get an error because the guide is not found, try other guides from the sidebar.",
-  getGuideParams.shape,
+  getGuideParams().shape,
   getGuide
 );
 const transport = new StdioServerTransport();

--- a/params.ts
+++ b/params.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { findGuideParamsPrompt } from "./utils";
+import { getFindGuideParamsPrompt } from "./utils";
 
-
-export const getGuideParams = z.object({
-  guideLink: z.string().describe(findGuideParamsPrompt),
-});
-
+export function getGuideParams() {
+  return z.object({
+    guideLink: z.string().describe(getFindGuideParamsPrompt()),
+  });
+}

--- a/utils.ts
+++ b/utils.ts
@@ -9,7 +9,8 @@ export function getFormattedSidebar() {
   return sidebar;
 }
 
-export const findGuideParamsPrompt = `
+export function getFindGuideParamsPrompt() {
+  return `
     This is the path to the technical documentation to create actions from.
     To get the steps list, you need to pass the guideLink to the BuildOnBase getGuide tool.
     From the user prompt, find the most relevant guide from the sidebar of the docs website.
@@ -21,6 +22,7 @@ export const findGuideParamsPrompt = `
   
     You will find that in the sidebar list, the guide is under the "Smart Wallet" section.
     `;
+}
 
 export const testingPrompt = (code: string) => {
   return `


### PR DESCRIPTION
Fixes #13

Builds the guide prompt after the sidebar content has been refreshed, so the generated prompt uses the latest sidebar state instead of stale import-time content.

Keeps the change scoped to the guide prompt flow.